### PR TITLE
Shift setting multi line string to template rather than values file

### DIFF
--- a/.abs/main.yaml
+++ b/.abs/main.yaml
@@ -1,4 +1,4 @@
 replace-chart-version-with-git: true
 generate-metadata: true
-chart-dir: ./helm/security-pack
+chart-dir: ./helm/security-bundle
 destination: ./build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Changed the value type of configmap/secret values to object rather than multi line string.
+
 ## [0.13.0] - 2023-04-12
 
 ### Changed

--- a/helm/security-bundle/templates/apps.yaml
+++ b/helm/security-bundle/templates/apps.yaml
@@ -45,7 +45,7 @@ spec:
 {{- end }}
 {{- if $.Values.userConfig }}
 {{- with (get $.Values.userConfig $key) }}
-{{- if .configMap }}
+{{- if ((.configMap).values) }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -55,9 +55,10 @@ metadata:
   name: {{ $appName }}-user-values
   namespace: {{ $.Release.Namespace }}
 data:
-  {{- (tpl (.configMap | toYaml | toString) $) | nindent 2 }}
+  values: |
+  {{- (tpl (.configMap.values | toYaml | toString) $) | nindent 4 }}
 {{- end }}
-{{- if .secret }}
+{{- if ((.secret).values) }}
 ---
 apiVersion: v1
 kind: Secret
@@ -67,7 +68,8 @@ metadata:
   name: {{ $appName }}-user-secrets
   namespace: {{ $.Release.Namespace }}
 stringData:
-  {{- (tpl (.secret | toYaml | toString) $) | nindent 2 }}
+  values: |
+  {{- (tpl (.secret.values | toYaml | toString) $) | nindent 4 }}
 {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
This PR:

- changes the <APP>.configmap/secret.values value from multi-line string to object. This changes makes it possible for config keys to be overridden individually rather than the whole configmap values (limitation of how helm handles multi line strings). This is only benefical if teams want to override config via the parent app in this case, security-bundle.


We use flux and override certain key's values depending on environment etc. Currently we have to copy the whole multi line config if we only want to change one value in a child app. With this change we can get the benefits of kustomize doing its overlays properly.

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
