### PR TITLE
Disable PSPs for all the apps and set Kyverno to Enforce mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,18 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Set `Kyverno Policies` config to `Enforce` mode.
 - Disable PSPs for all Apps from `userConfig`.
-
-## [0.17.1] - 2023-06-15
-
-### Changed
-
 - Updated `kyverno` (App) to version 0.14.8, which modifies the PSPs logic so it can be disabled for every component.
-
-## [0.17.0] - 2023-06-15
-
-### Changed
-
-- Disable PSPs for `Kyverno` App from userConfig.
 
 ## [0.16.0] - 2023-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Set `Kyverno Policies` config to `Enforce` mode.
+- Disable PSPs for all Apps from `userConfig`.
+
 ## [0.17.1] - 2023-06-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ More information and configuration options can be found in each app repository.
 
 :warning: **Existing `security-pack` users must delete the old `security-pack` CR first before installing the bundle.** It is not possible to update directly from a `security-pack` to a `security-bundle` App CR by renaming it.
 
-:warning: **In version `0.17.0` PSPs are disabled by default. Clusters running versions older than `1.25.0` must enable the PSPs in the userconfig of the `values.yaml` file before installing the security bundle**
+:warning: **In version `v1.0.0` PSPs are disabled by default. Clusters running versions older than `1.25.0` must enable the PSPs in the userconfig of the `values.yaml` file before installing the Security Bundle or use older `v0.x.x` versions.**
 
 ### Updating from `security-pack`
 

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -5,23 +5,37 @@ organization: ""
 # using the structure shown below.
 
 userConfig:
-#  kyvernoPolicies:
-#    configMap:
-#      values:
-#        kyverno-policies:
-#          validationFailureAction: Enforce
+  falco:
+    configMap:
+      values:
+        podSecurityPolicy:
+          create: false
+  jiralert:
+    configMap:
+      values:
+        psp:
+          enabled: false
   kyverno:
     configMap:
       values:
         psp:
           enabled: false
-
-#   trivy:
-#     configMap:
-#       values:
-#         trivy:
-#           networkPolicy:
-#             enabled: false
+  # kyvernoPolicies:
+  #   configMap:
+  #     values:
+  #       kyverno-policies:
+  #         validationFailureAction: Enforce
+  trivy:
+    configMap:
+      values:
+        trivy:
+          rbac:
+            pspEnabled: false
+  trivyOperator:
+    configMap:
+      values:
+        rbac:
+          pspEnabled: false
 
 apps:
   falco:

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -20,11 +20,11 @@ userConfig:
       values:
         psp:
           enabled: false
-  # kyvernoPolicies:
-  #   configMap:
-  #     values:
-  #       kyverno-policies:
-  #         validationFailureAction: Enforce
+  kyvernoPolicies:
+    configMap:
+      values:
+        kyverno-policies:
+          validationFailureAction: Enforce
   trivy:
     configMap:
       values:


### PR DESCRIPTION
In Kubernetes version v1.25 PodSecurityPolicy CRD is not present anymore, which will cause Apps to fail when they try to install them. We already disabled this for Kyverno in bundle version v0.17.1, but we may want to do the same for the rest of the apps for full v1.25+ support out of the box.