### PR TITLE
legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2] - 2023-07-05
+
 ### Added
 
 - Add depends-on annotation to set App depenencies.
@@ -212,7 +214,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release containing (Giant Swarm apps) Falco 0.3.1, Kyverno 0.9.1, Starboard 0.6.0, Starboard exporter 0.3.1, and Trivy 0.2.0.
 
-[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.16.1...HEAD
+[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.16.2...HEAD
+[0.16.2]: https://github.com/giantswarm/security-bundle/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/giantswarm/security-bundle/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/giantswarm/security-bundle/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/giantswarm/security-bundle/compare/v0.14.3...v0.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2023-06-26
+
 ### Changed
 
 - Update to `kyverno` (app) version 0.14.9, introducing the `scrapeTimeout` and `interval` configurable values for Policy Reporter `ServiceMonitors`.
@@ -201,7 +203,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release containing (Giant Swarm apps) Falco 0.3.1, Kyverno 0.9.1, Starboard 0.6.0, Starboard exporter 0.3.1, and Trivy 0.2.0.
 
-[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/giantswarm/security-bundle/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/giantswarm/security-bundle/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/giantswarm/security-bundle/compare/v0.14.3...v0.15.0
 [0.14.3]: https://github.com/giantswarm/security-bundle/compare/v0.14.2...v0.14.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update to `kyverno` (app) version 0.14.9, introducing the `scrapeTimeout` and `interval` configurable values for Policy Reporter `ServiceMonitors`.
+
 ## [0.16.0] - 2023-06-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Update to `kyverno` (app) upstream version 1.10.2. *Note:* This update includes breaking changes in the values structure, please check the [migration docs](https://github.com/giantswarm/kyverno-app/tree/main/helm/kyverno/charts/kyverno#new-chart-values) before upgrading.
+- Update to `trivy` (app) version 0.8.3.
+- Update to `falco` (app) version 0.6.5.
+
+
 ## [0.16.2] - 2023-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add depends-on annotation to set App depenencies.
+
+### Changed
+
+- Update to `kyverno` (app) version 0.14.10, introducing Cilium Network Policy support.
+- Update to `kyverno-policies` (app) version 0.20.0.
+
 ## [0.16.1] - 2023-06-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2023-09-11
+
 ### Added
 
 - Update to `kyverno` (app) upstream version 1.10.2. *Note:* This update includes breaking changes in the values structure, please check the [migration docs](https://github.com/giantswarm/kyverno-app/tree/main/helm/kyverno/charts/kyverno#new-chart-values) before upgrading.
@@ -221,7 +223,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release containing (Giant Swarm apps) Falco 0.3.1, Kyverno 0.9.1, Starboard 0.6.0, Starboard exporter 0.3.1, and Trivy 0.2.0.
 
-[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.16.2...HEAD
+[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/giantswarm/security-bundle/compare/v0.16.2...v0.17.0
 [0.16.2]: https://github.com/giantswarm/security-bundle/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/giantswarm/security-bundle/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/giantswarm/security-bundle/compare/v0.15.0...v0.16.0

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ More information and configuration options can be found in each app repository.
 
 :warning: **Existing `security-pack` users must delete the old `security-pack` CR first before installing the bundle.** It is not possible to update directly from a `security-pack` to a `security-bundle` App CR by renaming it.
 
+### Compatibility Matrix
+
+| Bundle Version  | K8s Version  | GS Release  | Branch  | PSS Policy State  | PSPs installed |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| v1.0.x  |  >= v1.25.0 | >= v20.0.0  | `main`  | enforce  | no  |
+| v0.x.x  | < v1.25.0 | >= v19.1.0, < v20.0.0  | `legacy`  | audit  | yes  |
+
+### Upgrading from a self-managed to a preinstalled `security-bundle`
+
+The `security-bundle` is now being installed by default in new Giant Swarm cluster versions.
+
+When upgrading from a cluster where the bundle was not preinstalled, it is possible that the installation of the bundle will fail if the bundle itself, or one of its apps (like Kyverno) was installed as an optional app prior to the upgrade.
+
+We are working on an automated way to resolve this condition, but due to technical limitations and variation between how customers manage Apps (e.g. gitops) we currently recommend uninstalling any customer-installed `security-bundle`, `kyverno-app`, and `kyverno-policies` Apps installed in a cluster when upgrading to a version containing the bundle by default. 
+
 ### Updating from `security-pack`
 
 To change an existing `security-pack` install to a `security-bundle`, the following changes must be made:

--- a/helm/security-bundle/Chart.yaml
+++ b/helm/security-bundle/Chart.yaml
@@ -6,7 +6,7 @@ engine: gotpl
 home: https://github.com/giantswarm/security-bundle
 sources:
   - https://github.com/giantswarm/security-bundle
-version: 0.16.0
+version: 0.16.1
 annotations:
   application.giantswarm.io/in-cluster-app: "true"
   application.giantswarm.io/team: "shield"

--- a/helm/security-bundle/Chart.yaml
+++ b/helm/security-bundle/Chart.yaml
@@ -6,7 +6,7 @@ engine: gotpl
 home: https://github.com/giantswarm/security-bundle
 sources:
   - https://github.com/giantswarm/security-bundle
-version: 0.16.1
+version: 0.16.2
 annotations:
   application.giantswarm.io/in-cluster-app: "true"
   application.giantswarm.io/team: "shield"

--- a/helm/security-bundle/Chart.yaml
+++ b/helm/security-bundle/Chart.yaml
@@ -6,7 +6,7 @@ engine: gotpl
 home: https://github.com/giantswarm/security-bundle
 sources:
   - https://github.com/giantswarm/security-bundle
-version: 0.16.2
+version: 0.17.0
 annotations:
   application.giantswarm.io/in-cluster-app: "true"
   application.giantswarm.io/team: "shield"

--- a/helm/security-bundle/templates/apps.yaml
+++ b/helm/security-bundle/templates/apps.yaml
@@ -5,6 +5,16 @@
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
+  {{- if .dependsOn }}
+  annotations:
+    {{- if hasPrefix "org-" $.Release.Namespace }}
+    # App is deployed in the org- namespace so the secret name is prefixed by the cluster-id
+    app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterID .dependsOn -}}
+    {{- else }}
+    # App is deployed in the cluster-id namespace so prefix is unneeded
+    app-operator.giantswarm.io/depends-on: {{ .dependsOn -}}
+    {{- end }}
+  {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ $appName }}

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -47,7 +47,7 @@ apps:
     namespace: kyverno
     # used by renovate
     # repo: giantswarm/kyverno-app
-    version: 0.14.7
+    version: 0.14.9
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -47,7 +47,7 @@ apps:
     namespace: kyverno
     # used by renovate
     # repo: giantswarm/kyverno-app
-    version: 0.14.9
+    version: 0.14.10
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/
@@ -55,11 +55,12 @@ apps:
     appName: kyverno-policies
     chartName: kyverno-policies
     catalog: giantswarm
+    dependsOn: kyverno
     enabled: true
     namespace: kyverno
     # used by renovate
     # repo: giantswarm/kyverno-policies
-    version: 0.19.0
+    version: 0.20.0
 
   starboardExporter:
     appName: starboard-exporter

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -27,7 +27,7 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/falco-app
-    version: 0.5.2
+    version: 0.6.5
 
   jiralert:
     appName: jiralert
@@ -47,7 +47,7 @@ apps:
     namespace: kyverno
     # used by renovate
     # repo: giantswarm/kyverno-app
-    version: 0.14.10
+    version: 0.15.2
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/
@@ -80,7 +80,7 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/trivy-app
-    version: 0.8.1
+    version: 0.8.3
 
   trivyOperator:
     appName: trivy-operator


### PR DESCRIPTION
- Bump Kyverno to version 0.14.9 (#133)
- Release v0.16.1 (#135)
- Update legacy branch (#145)
- Release v0.16.2 (#147)
- Update dependencies Kyverno, Falco and Trivy  (#156)
- Release v0.17.0 (#158)
