### PR TITLE
Bump kyverno-policy-operator and exception-recommender to version 0.0.2

### DIFF
--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -59,7 +59,7 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/exception-recommender
-    version: 0.0.1
+    version: 0.0.2
 
   falco:
     appName: falco
@@ -100,7 +100,7 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/kyverno-policy-operator
-    version: 0.0.1
+    version: 0.0.2
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/


### PR DESCRIPTION
This PR bumps both KPO and exception-recommender so they don't get blocked by PSS