### PR TITLE
Bump kyverno-policy-operator and exception-recommender on legacy

### DIFF
--- a/.github/workflows/zz_generated.add-team-labels.yaml
+++ b/.github/workflows/zz_generated.add-team-labels.yaml
@@ -45,7 +45,7 @@ jobs:
         done
         echo "EOF" >> $GITHUB_ENV
     - name: Apply label to issue
-      if: ${{ env.LABEL != '' }}
+      if: ${{ env.LABEL != '' && env.LABEL != 'null' && env.LABEL != null }}
       uses: actions-ecosystem/action-add-labels@v1
       with:
         github_token: ${{ secrets.ISSUE_AUTOMATION }}

--- a/.github/workflows/zz_generated.add-to-project-board.yaml
+++ b/.github/workflows/zz_generated.add-to-project-board.yaml
@@ -56,7 +56,7 @@ jobs:
 
         echo "BOARD=${BOARD}" >> $GITHUB_ENV
     - name: Add issue to personal board
-      if: ${{ env.BOARD != 'null' && env.BOARD != '' }}
+      if: ${{ env.BOARD != 'null' && env.BOARD != ''  && env.BOARD != null }}
       uses: actions/add-to-project@main
       with:
         project-url: ${{ env.BOARD }}
@@ -82,7 +82,7 @@ jobs:
 
         echo "BOARD=${BOARD}" >> $GITHUB_ENV
     - name: Add issue to team board
-      if: ${{ env.BOARD != 'null' && env.BOARD != '' }}
+      if: ${{ env.BOARD != 'null' && env.BOARD != '' && env.BOARD != null }}
       uses: actions/add-to-project@main
       with:
         project-url: ${{ env.BOARD }}

--- a/.github/workflows/zz_generated.check_values_schema.yaml
+++ b/.github/workflows/zz_generated.check_values_schema.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.1.1
+#    devctl@6.13.0
 #
 name: 'Values and schema'
 on:
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/zz_generated.create_release.yaml
+++ b/.github/workflows/zz_generated.create_release.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.1.1
+#    devctl@6.13.0
 #
 name: Create Release
 on:
@@ -53,7 +53,7 @@ jobs:
           echo "version=${version}" >> $GITHUB_OUTPUT
       - name: Checkout code
         if: ${{ steps.get_version.outputs.version != '' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Get project.go path
         id: get_project_go_path
         if: ${{ steps.get_version.outputs.version != '' }}
@@ -103,7 +103,7 @@ jobs:
           tarball_binary_path: "*/src/${binary}"
           smoke_test: "${binary} --version"
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Update project.go
         id: update_project_go
         env:
@@ -143,7 +143,7 @@ jobs:
           version: "${{ needs.gather_facts.outputs.version }}"
           title: "Bump version to ${{ steps.update_project_go.outputs.new_version }}"
         run: |
-          hub pull-request -f  -m "${{ env.title }}" -b ${{ env.base }} -h ${{ env.branch }} -r ${{ github.actor }}
+          gh pr create --title "${{ env.title }}" --body "" --base ${{ env.base }} --head ${{ env.branch }} --reviewer ${{ github.actor }}
   create_release:
     name: Create release
     runs-on: ubuntu-20.04
@@ -154,7 +154,7 @@ jobs:
       upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
       - name: Ensure correct version in project.go
@@ -208,7 +208,7 @@ jobs:
           tarball_binary_path: "*/src/${binary}"
           smoke_test: "${binary} --version"
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Clone the whole history, not just the most recent commit.
       - name: Fetch all tags and branches

--- a/.github/workflows/zz_generated.create_release_pr.yaml
+++ b/.github/workflows/zz_generated.create_release_pr.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.1.1
+#    devctl@6.13.0
 #
 name: Create Release PR
 on:
@@ -152,7 +152,7 @@ jobs:
           binary: "architect"
           version: "6.11.0"
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ needs.gather_facts.outputs.branch }}
       - name: Prepare release changes
@@ -227,4 +227,4 @@ jobs:
           base: "${{ needs.gather_facts.outputs.base }}"
           version: "${{ needs.gather_facts.outputs.version }}"
         run: |
-          hub pull-request -f -m "Release v${{ env.version }}" -a ${{ github.actor }} -b ${{ env.base }} -h ${{ needs.gather_facts.outputs.branch }}
+          gh pr create --assignee ${{ github.actor }} --title "Release v${{ env.version }}" --body "" --base ${{ env.base }} --head "${{ needs.gather_facts.outputs.branch }}"

--- a/.github/workflows/zz_generated.gitleaks.yaml
+++ b/.github/workflows/zz_generated.gitleaks.yaml
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.1.1
+#    devctl@6.13.0
 #
 name: gitleaks
 
@@ -10,7 +10,7 @@ jobs:
   gitleaks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: '0'
     - name: gitleaks-action

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.2] - 2023-07-05
+
 ### Added
 
 - Add depends-on annotation to set App depenencies.
@@ -212,7 +214,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release containing (Giant Swarm apps) Falco 0.3.1, Kyverno 0.9.1, Starboard 0.6.0, Starboard exporter 0.3.1, and Trivy 0.2.0.
 
-[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.16.1...HEAD
+[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.16.2...HEAD
+[0.16.2]: https://github.com/giantswarm/security-bundle/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/giantswarm/security-bundle/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/giantswarm/security-bundle/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/giantswarm/security-bundle/compare/v0.14.3...v0.15.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.16.1] - 2023-06-26
+
 ### Changed
 
 - Update to `kyverno` (app) version 0.14.9, introducing the `scrapeTimeout` and `interval` configurable values for Policy Reporter `ServiceMonitors`.
@@ -201,7 +203,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release containing (Giant Swarm apps) Falco 0.3.1, Kyverno 0.9.1, Starboard 0.6.0, Starboard exporter 0.3.1, and Trivy 0.2.0.
 
-[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.16.1...HEAD
+[0.16.1]: https://github.com/giantswarm/security-bundle/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/giantswarm/security-bundle/compare/v0.15.0...v0.16.0
 [0.15.0]: https://github.com/giantswarm/security-bundle/compare/v0.14.3...v0.15.0
 [0.14.3]: https://github.com/giantswarm/security-bundle/compare/v0.14.2...v0.14.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update to `kyverno` (app) version 0.14.9, introducing the `scrapeTimeout` and `interval` configurable values for Policy Reporter `ServiceMonitors`.
+
 ## [0.16.0] - 2023-06-13
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add `exception-recommender` (app) to the security bundle to create Giant Swarm PolicyException recommendations.
+- Add `kyverno-policy-operator` (app) to the security bundle to automatically create Kyverno PolicyExceptions from Giant Swarm PolicyExceptions.
+
 ## [0.17.0] - 2023-09-11
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.18.0] - 2023-10-05
+
 ### Added
 
 - Add `exception-recommender` (app) to the security bundle to create Giant Swarm PolicyException recommendations.
@@ -230,7 +232,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release containing (Giant Swarm apps) Falco 0.3.1, Kyverno 0.9.1, Starboard 0.6.0, Starboard exporter 0.3.1, and Trivy 0.2.0.
 
-[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.17.0...HEAD
+[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.18.0...HEAD
+[0.18.0]: https://github.com/giantswarm/security-bundle/compare/v0.17.0...v0.18.0
 [0.17.0]: https://github.com/giantswarm/security-bundle/compare/v0.16.2...v0.17.0
 [0.16.2]: https://github.com/giantswarm/security-bundle/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/giantswarm/security-bundle/compare/v0.16.0...v0.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `exception-recommender` (app) to the security bundle to create Giant Swarm PolicyException recommendations.
 - Add `kyverno-policy-operator` (app) to the security bundle to automatically create Kyverno PolicyExceptions from Giant Swarm PolicyExceptions.
+- Update to `kyverno-policies` (app) version 0.20.1.
+- Update to `trivy-operator` (app) to version 0.4.1.
 
 ## [0.17.0] - 2023-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update to `exception-recommender` (app) version 0.0.2.
+- Update to `kyverno-policy-operator` (app) version 0.0.2.
+
 ## [0.18.0] - 2023-10-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Update to `kyverno` (app) upstream version 1.10.2. *Note:* This update includes breaking changes in the values structure, please check the [migration docs](https://github.com/giantswarm/kyverno-app/tree/main/helm/kyverno/charts/kyverno#new-chart-values) before upgrading.
+- Update to `trivy` (app) version 0.8.3.
+- Update to `falco` (app) version 0.6.5.
+
+
 ## [0.16.2] - 2023-07-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add depends-on annotation to set App depenencies.
+
+### Changed
+
+- Update to `kyverno` (app) version 0.14.10, introducing Cilium Network Policy support.
+- Update to `kyverno-policies` (app) version 0.20.0.
+
 ## [0.16.1] - 2023-06-26
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2023-09-11
+
 ### Added
 
 - Update to `kyverno` (app) upstream version 1.10.2. *Note:* This update includes breaking changes in the values structure, please check the [migration docs](https://github.com/giantswarm/kyverno-app/tree/main/helm/kyverno/charts/kyverno#new-chart-values) before upgrading.
@@ -221,7 +223,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Initial release containing (Giant Swarm apps) Falco 0.3.1, Kyverno 0.9.1, Starboard 0.6.0, Starboard exporter 0.3.1, and Trivy 0.2.0.
 
-[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.16.2...HEAD
+[Unreleased]: https://github.com/giantswarm/security-bundle/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/giantswarm/security-bundle/compare/v0.16.2...v0.17.0
 [0.16.2]: https://github.com/giantswarm/security-bundle/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/giantswarm/security-bundle/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/giantswarm/security-bundle/compare/v0.15.0...v0.16.0

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.1.1
+#    devctl@6.13.0
 #
 
 include Makefile.*.mk

--- a/Makefile.gen.app.mk
+++ b/Makefile.gen.app.mk
@@ -1,6 +1,6 @@
 # DO NOT EDIT. Generated with:
 #
-#    devctl@6.1.1
+#    devctl@6.13.0
 #
 
 ##@ App

--- a/README.md
+++ b/README.md
@@ -29,6 +29,21 @@ More information and configuration options can be found in each app repository.
 
 :warning: **Existing `security-pack` users must delete the old `security-pack` CR first before installing the bundle.** It is not possible to update directly from a `security-pack` to a `security-bundle` App CR by renaming it.
 
+### Compatibility Matrix
+
+| Bundle Version  | K8s Version  | GS Release  | Branch  | PSS Policy State  | PSPs installed |
+|:---:|:---:|:---:|:---:|:---:|:---:|
+| v1.0.x  |  >= v1.25.0 | >= v20.0.0  | `main`  | enforce  | no  |
+| v0.x.x  | < v1.25.0 | >= v19.1.0, < v20.0.0  | `legacy`  | audit  | yes  |
+
+### Upgrading from a self-managed to a preinstalled `security-bundle`
+
+The `security-bundle` is now being installed by default in new Giant Swarm cluster versions.
+
+When upgrading from a cluster where the bundle was not preinstalled, it is possible that the installation of the bundle will fail if the bundle itself, or one of its apps (like Kyverno) was installed as an optional app prior to the upgrade.
+
+We are working on an automated way to resolve this condition, but due to technical limitations and variation between how customers manage Apps (e.g. gitops) we currently recommend uninstalling any customer-installed `security-bundle`, `kyverno-app`, and `kyverno-policies` Apps installed in a cluster when upgrading to a version containing the bundle by default. 
+
 ### Updating from `security-pack`
 
 To change an existing `security-pack` install to a `security-bundle`, the following changes must be made:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ By default, installing the security bundle in a cluster includes:
 - Kyverno, from our [`kyverno-app`][kyverno-app]
   - our [`kyverno-policies`][kyverno-policies] app for Kubernetes Pod Security Standards (PSS)
 
+- components supporting our Policy API features
+  - our [`kyverno-policy-operator`][kyverno-policy-operator] app, which orchestrates our managed Kyverno policies.
+  - our [`exception-recommender`][exception-recommender] app, which recommends possible Giant Swarm PolicyExceptions for non-compliant workloads.
+
 Some optional components are also installable from this bundle, including:
 
 - Falco, from our [`falco-app`][falco-app]
@@ -34,7 +38,8 @@ More information and configuration options can be found in each app repository.
 | Bundle Version  | K8s Version  | GS Release  | Branch  | PSS Policy State  | PSPs installed |
 |:---:|:---:|:---:|:---:|:---:|:---:|
 | v1.0.x  |  >= v1.25.0 | >= v20.0.0  | `main`  | enforce  | no  |
-| v0.x.x  | < v1.25.0 | >= v19.1.0, < v20.0.0  | `legacy`  | audit  | yes  |
+| v1.0.x  |  v1.24.x | >= v19.2.0, < v20.0.0  | `main`  | enforce  |  |
+| v0.x.x  | < v1.25.0 | >= v19.1.0, < v19.2.0  | `legacy`  | audit  | yes  |
 
 ### Upgrading from a self-managed to a preinstalled `security-bundle`
 
@@ -160,10 +165,12 @@ metadata:
 See our [full reference page on how to configure applications](https://docs.giantswarm.io/app-platform/app-configuration/) for more details.
 
 [app-bundle]: https://docs.giantswarm.io/getting-started/app-platform/app-bundle/
+[exception-recommender]: https://github.com/giantswarm/exception-recommender
 [falco-app]: https://github.com/giantswarm/falco-app
 [jiralert-app]: https://github.com/giantswarm/jiralert-app
 [kyverno-app]: https://github.com/giantswarm/kyverno-app
 [kyverno-policies]: https://github.com/giantswarm/kyverno-policies/
+[kyverno-policy-operator]: https://github.com/giantswarm/kyverno-policy-operator
 [security-bundle]: https://docs.giantswarm.io/app-platform/apps/security/
 [starboard-app]: https://github.com/giantswarm/starboard-app
 [starboard-exporter]: https://github.com/giantswarm/starboard-exporter/

--- a/helm/security-bundle/Chart.yaml
+++ b/helm/security-bundle/Chart.yaml
@@ -6,7 +6,7 @@ engine: gotpl
 home: https://github.com/giantswarm/security-bundle
 sources:
   - https://github.com/giantswarm/security-bundle
-version: 0.16.0
+version: 0.16.1
 annotations:
   application.giantswarm.io/in-cluster-app: "true"
   application.giantswarm.io/team: "shield"

--- a/helm/security-bundle/Chart.yaml
+++ b/helm/security-bundle/Chart.yaml
@@ -6,7 +6,7 @@ engine: gotpl
 home: https://github.com/giantswarm/security-bundle
 sources:
   - https://github.com/giantswarm/security-bundle
-version: 0.16.1
+version: 0.16.2
 annotations:
   application.giantswarm.io/in-cluster-app: "true"
   application.giantswarm.io/team: "shield"

--- a/helm/security-bundle/Chart.yaml
+++ b/helm/security-bundle/Chart.yaml
@@ -6,7 +6,7 @@ engine: gotpl
 home: https://github.com/giantswarm/security-bundle
 sources:
   - https://github.com/giantswarm/security-bundle
-version: 0.17.0
+version: 0.18.0
 annotations:
   application.giantswarm.io/in-cluster-app: "true"
   application.giantswarm.io/team: "shield"

--- a/helm/security-bundle/Chart.yaml
+++ b/helm/security-bundle/Chart.yaml
@@ -6,7 +6,7 @@ engine: gotpl
 home: https://github.com/giantswarm/security-bundle
 sources:
   - https://github.com/giantswarm/security-bundle
-version: 0.16.2
+version: 0.17.0
 annotations:
   application.giantswarm.io/in-cluster-app: "true"
   application.giantswarm.io/team: "shield"

--- a/helm/security-bundle/templates/apps.yaml
+++ b/helm/security-bundle/templates/apps.yaml
@@ -5,6 +5,16 @@
 apiVersion: application.giantswarm.io/v1alpha1
 kind: App
 metadata:
+  {{- if .dependsOn }}
+  annotations:
+    {{- if hasPrefix "org-" $.Release.Namespace }}
+    # App is deployed in the org- namespace so the secret name is prefixed by the cluster-id
+    app-operator.giantswarm.io/depends-on: {{ printf "%s-%s" $.Values.clusterID .dependsOn -}}
+    {{- else }}
+    # App is deployed in the cluster-id namespace so prefix is unneeded
+    app-operator.giantswarm.io/depends-on: {{ .dependsOn -}}
+    {{- end }}
+  {{- end }}
   labels:
     {{- include "labels.common" $ | nindent 4 }}
   name: {{ $appName }}

--- a/helm/security-bundle/values.schema.json
+++ b/helm/security-bundle/values.schema.json
@@ -5,6 +5,32 @@
         "apps": {
             "type": "object",
             "properties": {
+                "exceptionRecommender": {
+                    "type": "object",
+                    "properties": {
+                        "appName": {
+                            "type": "string"
+                        },
+                        "catalog": {
+                            "type": "string"
+                        },
+                        "chartName": {
+                            "type": "string"
+                        },
+                        "dependsOn": {
+                            "type": "string"
+                        },
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "namespace": {
+                            "type": "string"
+                        },
+                        "version": {
+                            "type": "string"
+                        }
+                    }
+                },
                 "falco": {
                     "type": "object",
                     "properties": {
@@ -86,6 +112,9 @@
                         "chartName": {
                             "type": "string"
                         },
+                        "dependsOn": {
+                            "type": "string"
+                        },
                         "enabled": {
                             "type": "boolean"
                         },
@@ -97,7 +126,7 @@
                         }
                     }
                 },
-                "starboard": {
+                "kyvernoPolicyOperator": {
                     "type": "object",
                     "properties": {
                         "appName": {
@@ -107,6 +136,9 @@
                             "type": "string"
                         },
                         "chartName": {
+                            "type": "string"
+                        },
+                        "dependsOn": {
                             "type": "string"
                         },
                         "enabled": {

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -28,7 +28,7 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/exception-recommender
-    version: 0.0.1
+    version: 0.0.2
 
   falco:
     appName: falco
@@ -69,7 +69,7 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/kyverno-policy-operator
-    version: 0.0.1
+    version: 0.0.2
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -47,7 +47,7 @@ apps:
     namespace: kyverno
     # used by renovate
     # repo: giantswarm/kyverno-app
-    version: 0.14.7
+    version: 0.14.9
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -47,7 +47,7 @@ apps:
     namespace: kyverno
     # used by renovate
     # repo: giantswarm/kyverno-app
-    version: 0.14.9
+    version: 0.14.10
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/
@@ -55,11 +55,12 @@ apps:
     appName: kyverno-policies
     chartName: kyverno-policies
     catalog: giantswarm
+    dependsOn: kyverno
     enabled: true
     namespace: kyverno
     # used by renovate
     # repo: giantswarm/kyverno-policies
-    version: 0.19.0
+    version: 0.20.0
 
   starboardExporter:
     appName: starboard-exporter

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -60,7 +60,7 @@ apps:
     namespace: kyverno
     # used by renovate
     # repo: giantswarm/kyverno-policies
-    version: 0.20.0
+    version: 0.20.1
 
   starboardExporter:
     appName: starboard-exporter
@@ -90,4 +90,4 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/trivy-operator-app
-    version: 0.4.0
+    version: 0.4.1

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -19,6 +19,17 @@ organization: ""
 #             enabled: false
 
 apps:
+  exceptionRecommender:
+    appName: exception-recommender
+    chartName: exception-recommender
+    catalog: giantswarm
+    dependsOn: kyverno
+    enabled: true
+    namespace: security-bundle
+    # used by renovate
+    # repo: giantswarm/exception-recommender
+    version: 0.0.1
+
   falco:
     appName: falco
     chartName: falco
@@ -48,6 +59,17 @@ apps:
     # used by renovate
     # repo: giantswarm/kyverno-app
     version: 0.15.2
+
+  kyvernoPolicyOperator:
+    appName: kyverno-policy-operator
+    chartName: kyverno-policy-operator
+    catalog: giantswarm
+    dependsOn: kyverno-policies
+    enabled: true
+    namespace: security-bundle
+    # used by renovate
+    # repo: giantswarm/kyverno-policy-operator
+    version: 0.0.1
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -27,7 +27,7 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/falco-app
-    version: 0.5.2
+    version: 0.6.5
 
   jiralert:
     appName: jiralert
@@ -47,7 +47,7 @@ apps:
     namespace: kyverno
     # used by renovate
     # repo: giantswarm/kyverno-app
-    version: 0.14.10
+    version: 0.15.2
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/
@@ -80,7 +80,7 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/trivy-app
-    version: 0.8.1
+    version: 0.8.3
 
   trivyOperator:
     appName: trivy-operator

--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,5 @@
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.*)$"
     }
-  ],
-  "schedule": [ "after 6am on thursday" ]
+  ]
 }


### PR DESCRIPTION
This makes the preinstall job go through PSS admission without failing. Not necessarily needed for this release channel but a nice to have.