### PR TITLE
Bump kyverno-policy-operator and exception-recommender on legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update to `exception-recommender` (app) version 0.0.2.
+- Update to `kyverno-policy-operator` (app) version 0.0.2.
+
 ## [0.18.0] - 2023-10-05
 
 ### Added

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -28,7 +28,7 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/exception-recommender
-    version: 0.0.1
+    version: 0.0.2
 
   falco:
     appName: falco
@@ -69,7 +69,7 @@ apps:
     namespace: security-bundle
     # used by renovate
     # repo: giantswarm/kyverno-policy-operator
-    version: 0.0.1
+    version: 0.0.2
 
   # Kyverno policies for Kubernetes Pod Security Standards (PSS).
   # From: https://github.com/giantswarm/kyverno-policies/


### PR DESCRIPTION
This makes the preinstall job go through PSS admission without failing. Not necessarily needed for this release channel but a nice to have.