### PR TITLE
Change kyverno-policy-operator and exception-recommender namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change `kyverno-policy-oeprator` and `exception-recommender` namespaces to `policy-exceptions`.
+- Change `kyverno-policy-operator` and `exception-recommender` namespaces to `policy-exceptions`.
 
 ## [1.1.0] - 2023-10-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Change `kyverno-policy-oeprator` and `exception-recommender` namespaces to `policy-exceptions`.
+
 ## [1.1.0] - 2023-10-10
 
 - Add `exception-recommender` (app) to the security bundle to create Giant Swarm PolicyException recommendations.

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -11,6 +11,8 @@ userConfig:
         global:
           podSecurityStandards:
             enforced: true
+        recommender:
+          createNamespace: false
   falco:
     configMap:
       values:
@@ -56,7 +58,7 @@ apps:
     catalog: giantswarm
     dependsOn: kyverno
     enabled: false
-    namespace: security-bundle
+    namespace: policy-exceptions
     # used by renovate
     # repo: giantswarm/exception-recommender
     version: 0.0.2
@@ -97,7 +99,7 @@ apps:
     catalog: giantswarm
     dependsOn: kyverno-policies
     enabled: true
-    namespace: security-bundle
+    namespace: policy-exceptions
     # used by renovate
     # repo: giantswarm/kyverno-policy-operator
     version: 0.0.2


### PR DESCRIPTION
This PR changes the default namespace from `security-bundle` to `policy-exceptions` for `kyverno-policy-operator` and `exception-recommender` apps.