### PR TITLE
Change kyverno-policy-operator and exception-recommender namespaces on legacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Change `kyverno-policy-oeprator` and `exception-recommender` namespaces to `policy-exceptions`.
 - Update to `exception-recommender` (app) version 0.0.2.
 - Update to `kyverno-policy-operator` (app) version 0.0.2.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Change `kyverno-policy-oeprator` and `exception-recommender` namespaces to `policy-exceptions`.
+- Change `kyverno-policy-operator` and `exception-recommender` namespaces to `policy-exceptions`.
 - Update to `exception-recommender` (app) version 0.0.2.
 - Update to `kyverno-policy-operator` (app) version 0.0.2.
 

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -18,6 +18,13 @@ organization: ""
 #           networkPolicy:
 #             enabled: false
 
+userConfig:
+  exceptionRecommender:
+    configMap:
+      values:
+        recommender:
+          createNamespace: false
+
 apps:
   exceptionRecommender:
     appName: exception-recommender
@@ -25,7 +32,7 @@ apps:
     catalog: giantswarm
     dependsOn: kyverno
     enabled: true
-    namespace: security-bundle
+    namespace: policy-exceptions
     # used by renovate
     # repo: giantswarm/exception-recommender
     version: 0.0.2
@@ -66,7 +73,7 @@ apps:
     catalog: giantswarm
     dependsOn: kyverno-policies
     enabled: true
-    namespace: security-bundle
+    namespace: policy-exceptions
     # used by renovate
     # repo: giantswarm/kyverno-policy-operator
     version: 0.0.2


### PR DESCRIPTION
This PR changes the default namespace from `security-bundle` to `policy-exceptions` for `kyverno-policy-operator` and `exception-recommender` apps.