### PR TITLE
Add a global value to set all apps namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add a `global.namespace` values for automatically setting all apps namespaces.
+- Add a `global.namespace` value for automatically setting all app namespaces.
 
 ## [1.4.2] - 2023-12-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add a `global.namespace` values for automatically setting all apps namespaces.
+
 ## [1.4.2] - 2023-12-07
 
 ### Changed

--- a/helm/security-bundle/templates/apps.yaml
+++ b/helm/security-bundle/templates/apps.yaml
@@ -51,7 +51,7 @@ spec:
       name: {{ $.Values.clusterID }}-kubeconfig
       namespace: {{ $.Release.Namespace}}
   name: {{ .chartName }}
-  namespace: {{ .namespace }}
+  namespace: {{ required "A valid .Values.global.namespace or .Values.apps.{APP_NAME}.namespace entry is required" (default ($.Values.global).namespace .namespace) }}
   version: {{ .version }}
   {{- if $.Values.userConfig }}
   {{- with (get $.Values.userConfig $key) }}

--- a/helm/security-bundle/values.schema.json
+++ b/helm/security-bundle/values.schema.json
@@ -226,6 +226,14 @@
         "clusterID": {
             "type": "string"
         },
+        "global": {
+            "type": "object",
+            "properties": {
+                "namespace": {
+                    "type": "string"
+                }
+            }
+        },
         "organization": {
             "type": "string"
         }

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -2,6 +2,7 @@ clusterID: ""
 organization: ""
 
 global:
+  # All Apps will be installed in this namespace unless overridden below.
   namespace: "security-bundle"
 
 # User values can be provided via a ConfigMap or Secret for each individual app

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -1,6 +1,9 @@
 clusterID: ""
 organization: ""
 
+global:
+  namespace: "security-bundle"
+
 # User values can be provided via a ConfigMap or Secret for each individual app
 # using the structure shown below.
 
@@ -65,7 +68,7 @@ apps:
     catalog: giantswarm
     dependsOn: kyverno
     enabled: false
-    namespace: security-bundle
+    # namespace: security-bundle
     # used by renovate
     # repo: giantswarm/exception-recommender
     version: 0.0.6
@@ -75,7 +78,7 @@ apps:
     chartName: falco
     catalog: giantswarm
     enabled: false
-    namespace: security-bundle
+    # namespace: security-bundle
     # used by renovate
     # repo: giantswarm/falco-app
     version: 0.7.0
@@ -85,7 +88,7 @@ apps:
     chartName: jiralert
     catalog: giantswarm
     enabled: false
-    namespace: security-bundle
+    # namespace: security-bundle
     # used by renovate
     # repo: giantswarm/jiralert-app
     version: 0.1.2
@@ -113,7 +116,7 @@ apps:
     catalog: giantswarm
     dependsOn: kyverno-policies
     enabled: true
-    namespace: security-bundle
+    # namespace: security-bundle
     # used by renovate
     # repo: giantswarm/kyverno-policy-operator
     version: 0.0.5
@@ -146,7 +149,7 @@ apps:
     chartName: trivy
     catalog: giantswarm
     enabled: false
-    namespace: security-bundle
+    # namespace: security-bundle
     # used by renovate
     # repo: giantswarm/trivy-app
     version: 0.9.0
@@ -156,7 +159,7 @@ apps:
     chartName: trivy-operator
     catalog: giantswarm
     enabled: false
-    namespace: security-bundle
+    # namespace: security-bundle
     # used by renovate
     # repo: giantswarm/trivy-operator-app
     version: 0.5.0


### PR DESCRIPTION
Closes: https://github.com/giantswarm/giantswarm/issues/29264

This PRs adds a new `.global.namespace` value to set all apps namespace at the same time. If an app has individually set it's own namespace through `.apps.namespace`, then the latter will take effect.