### PR TITLE
Automate CHANGELOG update after renovate merges

### DIFF
--- a/.github/workflows/update_changelog.yaml
+++ b/.github/workflows/update_changelog.yaml
@@ -1,0 +1,105 @@
+name: Update Changelog
+# This workflow is triggered by Renovate changes on the `values.yaml` file on main.
+on:
+  push:
+    branches:
+      - 'main'
+    paths:
+      - 'helm/**/values.yaml'
+jobs:
+  update_changelog:
+    if: ${{ github.actor == 'renovate[bot]' }}
+    name: Add Changelog entry
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HERALD_APP_ID }}
+          private-key: ${{ secrets.HERALD_APP_KEY }}
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate_token.outputs.token }}
+          persist-credentials: true
+          ref: "${{ github.event.ref }}"
+          fetch-depth: 0
+      - name: Set up git identity
+        run: |
+          git config --local user.email "149080493+heraldbot[bot]@users.noreply.github.com"
+          git config --local user.name "HeraldBot[bot]"
+      - name: Create changelog branch
+        id: create_branch
+        run: |
+          branch="automated-changelog-update"
+          
+          # Fetch origin
+          git fetch origin
+
+          # Check if branch exists
+          if [ -z $(git rev-parse --verify origin/$branch 2>/dev/null) ]
+          then
+            # Branch doesn't exist, create it
+            git checkout -b $branch
+          else
+            # Branch exists, use existing
+            git checkout $branch
+          fi
+          
+          # Output branch
+          echo "branch=${branch}" >> $GITHUB_OUTPUT
+      - name: Run Changelogger
+        id: run_changelogger
+        run: |
+          # Get commit message
+          commit="${{ github.event.head_commit.message }}"
+
+          # Extract version
+          appVersion=$(echo $commit | grep -oP 'v\d+\.\d+\.\d+')
+
+          # Extract the app name, removing giantswarm/ from it
+          appName=$(echo $commit | grep -oP 'giantswarm/[-a-zA-Z]*' | sed 's/giantswarm\///')
+
+          # Remove app suffix if present
+          appName=${appName%-app}
+
+          # Form the changelog line
+          newLine="- Update \`${appName}\` (app) to $appVersion."
+
+          # Output App/Version
+          app="${appName}@${appVersion}"
+          echo "app=${app}" >> $GITHUB_OUTPUT
+          echo "${app}"
+
+          go run ./hack/changelogger.go --add-changed "${newLine}" --changelog-path ${PWD}/CHANGELOG.md
+
+      - name: Commit new changes
+        id: commit_changes
+        run: |
+          git add -A
+          if git diff-index --quiet HEAD; then
+            echo "No changes found"
+          else
+            git commit -m "Add changelog entry for ${{ steps.run_changelogger.outputs.app }}"
+          fi
+      - name: Push changes
+        env:
+          remote_repo: "https://${{ github.actor }}:${{ steps.generate_token.outputs.token }}@github.com/${{ github.repository }}.git"
+        run: |
+          git push "${remote_repo}" HEAD:"${{ steps.create_branch.outputs.branch }}"
+      - name: Create PR
+        env:
+          GITHUB_TOKEN: "${{ steps.generate_token.outputs.token }}"
+        run: |
+          body="## Description
+
+          * Update \`CHANGELOG.md\` with new App version entries.
+
+
+          ---
+          > [!NOTE]  
+          > This PR was created by the **Update Changelog** workflow and triggered by a **Renovate** change on the \`values.yaml\` file.
+          "
+          # TODO: Check if PR exists instead
+          gh pr create --title "Bump App versions on changelog" --body "${body}" --head ${{ steps.create_branch.outputs.branch }} --base "${{ github.event.ref }}" || true

--- a/hack/changelogger.go
+++ b/hack/changelogger.go
@@ -1,0 +1,195 @@
+package main
+
+import (
+	"flag"
+	"log"
+	"os"
+	"strings"
+)
+
+var logger *log.Logger
+var addChangedLine string
+var changelogPath string
+
+type Changelog struct {
+	Title    string    `json:"title"`
+	Notes    []string  `json:"notes"`
+	Versions []Version `json:"versions"`
+	Refs     []string  `json:"refs"`
+}
+
+type Version struct {
+	Name    string   `json:"name"`
+	Changed []string `json:"changed"`
+	Added   []string `json:"added"`
+	Fixed   []string `json:"fixed"`
+	Removed []string `json:"removed"`
+	Notes   []string `json:"notes"`
+}
+
+func init() {
+	logger = log.New(os.Stdout, "", 644)
+}
+
+func main() {
+	// Flags
+	flag.StringVar(&addChangedLine, "add-changed", "", "Adds a new Changed entry to the Unreleased section of the changelog")
+	flag.StringVar(&changelogPath, "changelog-path", "CHANGELOG.md", "Path to the changelog file")
+	flag.Parse()
+
+	data, err := os.ReadFile(changelogPath)
+	checkError(err)
+
+	lines := strings.Split(string(data), "\n")
+	lines = lines[:len(lines)-1]
+
+	// Convert the markdown file into a changelog struct
+	changelog := parseMarkdown(lines)
+
+	if addChangedLine != "" {
+		// Add a new Changed entry to the Unreleased section
+		logger.Println("Adding new Changed entry to the Unreleased section")
+		addChangedEntry(&changelog.Versions[0], addChangedLine)
+	}
+
+	// Write the new changelog file
+	err = writeChangelogFile(changelog, changelogPath)
+	checkError(err)
+
+	logger.Println("Changelog updated successfully")
+}
+
+func addChangedEntry(version *Version, entry string) {
+	version.Changed = append(version.Changed, entry)
+}
+
+func writeChangelogFile(newChangelog Changelog, path string) error {
+	lines := []string{}
+
+	lines = append(lines, newChangelog.Title+"\n")
+	if len(newChangelog.Notes) > 0 {
+		for _, note := range newChangelog.Notes {
+			lines = append(lines, note)
+		}
+	}
+	for _, version := range newChangelog.Versions {
+		lines = append(lines, version.Name+"\n")
+
+		if len(version.Added) != 0 {
+			header := "### Added\n"
+			lines = append(lines, header)
+
+			for _, item := range version.Added {
+				lines = append(lines, item)
+			}
+			lines = append(lines, "")
+		}
+		if len(version.Changed) != 0 {
+			header := "### Changed\n"
+			lines = append(lines, header)
+			for _, item := range version.Changed {
+				lines = append(lines, item)
+			}
+			lines = append(lines, "")
+		}
+		if len(version.Fixed) != 0 {
+			header := "### Fixed\n"
+			lines = append(lines, header)
+			for _, item := range version.Fixed {
+				lines = append(lines, item)
+			}
+			lines = append(lines, "")
+		}
+		if len(version.Removed) != 0 {
+			header := "### Removed\n"
+			lines = append(lines, header)
+			for _, item := range version.Removed {
+				lines = append(lines, item)
+			}
+			lines = append(lines, "")
+		}
+		if len(version.Notes) != 0 {
+			header := "### Notes\n"
+			lines = append(lines, header)
+			for _, item := range version.Notes {
+				lines = append(lines, item)
+			}
+			lines = append(lines, "")
+		}
+	}
+
+	for _, ref := range newChangelog.Refs {
+		lines = append(lines, ref)
+	}
+	// Append new line at the end of the file
+	lines = append(lines, "")
+
+	newFile := strings.Join(lines, "\n")
+
+	err := os.WriteFile(path, []byte(newFile), 666)
+
+	return err
+}
+
+func parseMarkdown(markdown []string) Changelog {
+	newChangelog := Changelog{}
+	newChangelog.Versions = []Version{}
+	populateVersion := false
+	currentlyPopulating := ""
+	currentVersion := &Version{}
+	for _, line := range markdown {
+		if len(line) > 0 {
+			header := strings.Split(line, " ")
+			// Identify headers
+			if header[0] == "#" {
+				populateVersion = true
+				newChangelog.Title = line
+			} else if header[0] == "##" {
+				populateVersion = false
+				newVersion := Version{}
+				newVersion.Name = line
+				newChangelog.Versions = append(newChangelog.Versions, newVersion)
+			} else if header[0] == "###" {
+				populateVersion = true
+				currentlyPopulating = header[1]
+			} else if strings.Contains(header[1], "https://") {
+				populateVersion = false
+				newChangelog.Refs = append(newChangelog.Refs, line)
+			} else {
+				if populateVersion {
+					if len(newChangelog.Versions) != 0 {
+						currentVersion = &newChangelog.Versions[len(newChangelog.Versions)-1]
+					}
+					switch currentlyPopulating {
+					case "":
+						newChangelog.Notes = append(newChangelog.Notes, line)
+						// Append a new line if the last char is a dot
+						if line[len(line)-1] == '.' {
+							newChangelog.Notes = append(newChangelog.Notes, "")
+						}
+					case "Added":
+						currentVersion.Added = append(currentVersion.Added, line)
+					case "Changed":
+						currentVersion.Changed = append(currentVersion.Changed, line)
+					case "Fixed":
+						currentVersion.Fixed = append(currentVersion.Fixed, line)
+					case "Removed":
+						currentVersion.Removed = append(currentVersion.Removed, line)
+					case "Notes":
+						currentVersion.Notes = append(currentVersion.Notes, line)
+					default:
+						continue
+					}
+				}
+			}
+		}
+	}
+
+	return newChangelog
+}
+
+func checkError(e error) {
+	if e != nil {
+		logger.Panic(e)
+	}
+}

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,0 +1,3 @@
+module giantswarm.io/changelogger
+
+go 1.21.6


### PR DESCRIPTION
This PR adds a new workflow to update the CHANGELOG after Renovate PRs are merged. This only affects `main` branch and modifications to the `values.yaml` file.