### PR TITLE
Bump CNPG to v0.0.5

### DIFF
--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -71,7 +71,7 @@ apps:
     namespace: giantswarm
     # used by renovate
     # repo: giantswarm/cloudnative-pg-app
-    version: 0.0.4
+    version: 0.0.5
 
   edgedb:
     appName: edgedb


### PR DESCRIPTION
This PR:

- bumps cloudnative-pg to v0.0.5

### Checklist

- [ ] Update changelog in CHANGELOG.md.
- [ ] Make sure `values.yaml` and `values.schema.json` are valid.
