### PR TITLE
Change dependsOn from kyverno to kyverno-crds

### DIFF
--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -96,7 +96,7 @@ apps:
     appName: exception-recommender
     chartName: exception-recommender
     catalog: giantswarm
-    dependsOn: kyverno
+    dependsOn: kyverno-crds
     enabled: false
     # namespace: security-bundle
     # used by renovate
@@ -155,7 +155,7 @@ apps:
     appName: kyverno-policy-operator
     chartName: kyverno-policy-operator
     catalog: giantswarm
-    dependsOn: kyverno
+    dependsOn: kyverno-crds
     enabled: true
     # namespace: security-bundle
     # used by renovate


### PR DESCRIPTION
Apps don't really need Kyverno in order to run, but its CRDs. This PR changes the dependencies to kyverno-crds instead of kyverno.

This should also help speed-up cluster creation.