### PR TITLE
Bump trivy operator to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Update `trivy-operator` (app) to v0.9.1.
+
 ## [1.7.1] - 2024-06-13
 
 ### Changed

--- a/helm/security-bundle/values.yaml
+++ b/helm/security-bundle/values.yaml
@@ -195,4 +195,4 @@ apps:
     # namespace: security-bundle
     # used by renovate
     # repo: giantswarm/trivy-operator-app
-    version: 0.9.0
+    version: 0.9.1


### PR DESCRIPTION
This PR:

- updates to trivy operator app 0.9.1, mirroring https://github.com/giantswarm/security-bundle/pull/407 and https://github.com/giantswarm/security-bundle/pull/406

### Checklist

- [x] Update changelog in CHANGELOG.md.
- [x] Make sure `values.yaml` and `values.schema.json` are valid.
